### PR TITLE
hotfix: cloudinaryで読み込む画像の高さ指定を削除

### DIFF
--- a/js/usecloudinary.js
+++ b/js/usecloudinary.js
@@ -10,8 +10,7 @@ function setsrc() {
         var display = images[i].style.display;
         if(display == "none") images[i].style.display = "block";
         var w = images[i].clientWidth;
-        var h = images[i].clientHeight;
-        images[i].src = "https://res.cloudinary.com/nztm/image/fetch/" + "w_" + w + ",h_" + h + ",c_fit,q_auto,f_auto/dpr_"+ window.devicePixelRatio + ".0/" + images[i].dataset.src;
+        images[i].src = "https://res.cloudinary.com/nztm/image/fetch/" + "w_" + w + ",c_fit,q_auto,f_auto/dpr_"+ window.devicePixelRatio + ".0/" + images[i].dataset.src;
         images[i].style.display = display;
       }
     }


### PR DESCRIPTION
ぼやけるので、高さは自動指定にしてみる

> 画像読み込み前にスクリプトが動いていて、正常な幅と高さを取れていない…？

と思われる