### PR TITLE
コースページの/をFontAwesomeの矢印に変える

### DIFF
--- a/_layouts/course.html
+++ b/_layouts/course.html
@@ -4,7 +4,7 @@ layout: default
 <section class="slide-page page-course" id="slidesCover">
 {{ content }}
 
-<a href="{{ site.baseurl }}/{{page.category}}#{{page.difficulty}}" class="label">{% t category.{{page.category}}.title %} / {% t difficulty.{{page.difficulty}} %}</a>
+<a href="{{ site.baseurl }}/{{page.category}}#{{page.difficulty}}" class="label">{% t category.{{page.category}}.title %} <i class="fas fa-angle-right"></i> {% t difficulty.{{page.difficulty}} %}</a>
 <div class="slides-top">
   <div class="slides-top-info">
   {% assign parents = site.courses | where:"course-name", page.parent %}


### PR DESCRIPTION
Before
<img width="172" alt="スクリーンショット 2020-07-02 14 20 08" src="https://user-images.githubusercontent.com/43288418/86319279-26689000-bc6f-11ea-8aac-35f75a1615df.png">

After
<img width="174" alt="スクリーンショット 2020-07-02 14 19 47" src="https://user-images.githubusercontent.com/43288418/86319284-28325380-bc6f-11ea-9ab2-1eb873ce983d.png">
