### PR TITLE
パンくずリストの翻訳関数を修正

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,7 +7,7 @@ layout: default
   <nav>
     <ol class="breadcrumbs">
       <li><a href="/">{% t top.title %}</a></li>
-      <li><i class="fas fa-angle-right"></i> <a href="/{{page.category}}">{% t top.{{page.category}} %}</a></li>
+      <li><i class="fas fa-angle-right"></i> <a href="/{{page.category}}">{% t {{page.category}}.title %}</a></li>
     </ol>
   </nav>
   <div class="post-content">


### PR DESCRIPTION
## ⛏ 変更内容 / Details of Changes
翻訳関数の変更により、パンくずリストにカテゴリ名が表示されていなかったのを修正。
<img width="208" alt="スクリーンショット 2020-07-06 21 25 57" src="https://user-images.githubusercontent.com/43288418/86593290-e63b4180-bfcf-11ea-988d-1f8176ed4caa.png">
