### PR TITLE
Reduce building time by jekyll-include-cache and liquid-c plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,15 @@ gem "minima", "~> 2.5"
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
+
+# Improve Liquid performance by Shopify's C extension
+# https://github.com/Shopify/liquid-c
+gem 'liquid-c'
+
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem 'jekyll-minifier'
+  gem "jekyll-include-cache"
   gem 'jekyll-sitemap'
   gem 'jekyll-pwa-plugin'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,8 @@ GEM
       terminal-table (~> 1.8)
     jekyll-feed (0.13.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-include-cache (0.2.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-minifier (0.1.10)
       cssminify2 (~> 2.0)
       htmlcompressor (~> 0.4)
@@ -59,6 +61,8 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
+    liquid-c (4.0.0)
+      liquid (>= 3.0.0)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -96,10 +100,12 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.0.0)
   jekyll-feed (~> 0.12)
+  jekyll-include-cache
   jekyll-minifier
   jekyll-multiple-languages-plugin (~> 1.6.1)
   jekyll-pwa-plugin
   jekyll-sitemap
+  liquid-c
   minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -47,6 +47,7 @@ jekyll-minifier:
 
 exclude:
   - src
+  - .jekyll-cache
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ url: "https://mekurun.com" # the base hostname & protocol for your site, e.g. ht
 markdown: MekurunCustomConverter
 plugins:
   - jekyll-feed
+  - jekyll-include-cache
   - jekyll-sitemap
   - jekyll-multiple-languages-plugin
   - jekyll-minifier


### PR DESCRIPTION
This PR makes building time a bit faster. 🛠💨✨

cf. [:scroll: How I reduced my Jekyll build time by 61% | Forestry.io](https://forestry.io/blog/how-i-reduced-my-jekyll-build-time-by-61/)
cf. [:octocat: Reduce 71.6% of building time by using Jekyll 4.0.0 #123 - yasslab.jp](https://github.com/yasslab/yasslab.jp/pull/123)

Hope the following benchmarks helpful for understanding how much this PR reduces the building time. 📊 :eyes: ✅ 

✏️ _NOTE: This repo already uses [Jekyll 4.0.0](https://jekyllrb.com/news/2019/08/20/jekyll-4-0-0-released/)+ so it's already speedy enough. 💨✨  This PR just improves it a bit by using [jekyll-include-cache](https://github.com/benbalter/jekyll-include-cache) and [liquid-c](https://github.com/Shopify/liquid-c) plugins. 😉_

## Before

<details>
<summary>Done in <b>2.81 seconds.</b> (Longest time out of 3 tries)</summary>

```
$ bundle exec jekyll build --profile

Configuration file: /Users/yasulab/mekurun.com/_config.yml
            Source: /Users/yasulab/mekurun.com
       Destination: /Users/yasulab/mekurun.com/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
Building site for default language: "ja" to: /Users/yasulab/mekurun.com/_site
       Jekyll Feed: Generating feed for posts
Loading translation from file /Users/yasulab/mekurun.com/_i18n/ja.yml
    Liquid Warning: Liquid syntax error (line 39): Expected dotdot but found comparison in "(course_lang == site.lang or (course_lang == 'ja' and site.lang == 'kana'))" in index.markdown

| Filename                   | Count |   Bytes |  Time |
+----------------------------+-------+---------+-------+
| sitemap.xml                |     1 |   3.08K | 0.021 |
| feed.xml                   |     1 |  15.32K | 0.018 |
| _layouts/course.html       |     8 |  49.84K | 0.014 |
| _layouts/page.html         |     9 |  37.51K | 0.013 |
| _layouts/default.html      |    23 | 221.64K | 0.011 |
| _includes/footer.html      |    15 |  22.85K | 0.011 |
| index.markdown             |     1 |   8.40K | 0.007 |
| _layouts/category.html     |     2 |   8.98K | 0.007 |
| _layouts/post.html         |     2 |  18.04K | 0.006 |
| faq.md                     |     1 |   3.61K | 0.006 |
| _includes/header.html      |    14 |  10.72K | 0.006 |
| term-of-use.md             |     1 |   2.57K | 0.005 |
| privacy.md                 |     1 |   4.40K | 0.005 |
| usage.md                   |     1 |   1.44K | 0.004 |
| _includes/course-list.html |     8 |   2.30K | 0.003 |
| projects.md                |     1 |   0.09K | 0.003 |
| about.md                   |     1 |   2.33K | 0.002 |
| tips.md                    |     1 |   0.83K | 0.002 |
| _includes/articles.html    |     6 |   1.85K | 0.002 |
| news.md                    |     1 |   0.06K | 0.001 |
| 404.html                   |     1 |   3.14K | 0.001 |
| contact.md                 |     1 |   0.62K | 0.000 |
+----------------------------+-------+---------+-------+
| TOTAL (for 22 files)       |   100 | 419.62K | 0.149 |

Building site for language: "en" to: /Users/yasulab/mekurun.com/_site/en
       Jekyll Feed: Generating feed for posts
Loading translation from file /Users/yasulab/mekurun.com/_i18n/en.yml
Missing i18n key: en:404
Using translation '404 Page Not Found' from default language: ja
Missing i18n key: en:about.description
Using translation 'メクルンについて知りたい方はこちらをご覧ください。' from default language: ja
Missing i18n key: en:contact.description
Using translation 'メクルンへのお問い合わせはこちらのフォームからお願いします。' from default language: ja
Missing i18n key: en:faq.description
Using translation 'メクルンのよくあるご質問についてはこちらをご覧ください。' from default language: ja
    Liquid Warning: Liquid syntax error (line 39): Expected dotdot but found comparison in "(course_lang == site.lang or (course_lang == 'ja' and site.lang == 'kana'))" in index.markdown
Missing i18n key: en:news.copy
Using translation 'メクルンからのアップデートやメンテナンスのお知らせ' from default language: ja
Missing i18n key: en:news.description
Using translation '運営からのお知らせを掲載しています。' from default language: ja
Missing i18n key: en:privacy.description
Using translation 'メクルンのプライバシーポリシーについてはこちらをご覧ください。' from default language: ja
Missing i18n key: en:projects.description
Using translation 'みんなのScratch(スクラッチ)やMakeCode(メイクコード)を使ったものづくりを紹介する記事を定期的に投稿しています。' from default language: ja
Missing i18n key: en:termOfUse.description
Using translation 'メクルンの教材コンテンツをご利用いただく際の規定についてはこちらをご覧ください。' from default language: ja
Missing i18n key: en:tips.copy
Using translation '作品を作るときに役立つ情報や、プログラミングに関する情報を紹介' from default language: ja
Missing i18n key: en:tips.description
Using translation 'Scratch(スクラッチ)やMakeCode(メイクコード)に関する豆知識やプログラミングやテクノロジーに関する記事を定期的に投稿しています。' from default language: ja
Missing i18n key: en:usage.description
Using translation 'メクルンの使い方についてはこちらをご覧ください。' from default language: ja

| Filename                   | Count |   Bytes |  Time |
+----------------------------+-------+---------+-------+
| _layouts/course.html       |     8 |  49.74K | 0.047 |
| sitemap.xml                |     1 |   2.94K | 0.030 |
| _layouts/page.html         |     9 |  33.68K | 0.022 |
| _includes/footer.html      |    13 |  18.42K | 0.016 |
| _layouts/default.html      |    21 | 181.22K | 0.015 |
| index.markdown             |     1 |   4.35K | 0.014 |
| _layouts/category.html     |     2 |   6.29K | 0.008 |
| feed.xml                   |     1 |   0.80K | 0.006 |
| privacy.md                 |     1 |   4.40K | 0.006 |
| _includes/header.html      |    12 |   6.54K | 0.005 |
| faq.md                     |     1 |   3.61K | 0.005 |
| usage.md                   |     1 |   1.44K | 0.003 |
| _includes/course-list.html |     8 |   0.53K | 0.003 |
| term-of-use.md             |     1 |   2.57K | 0.003 |
| projects.md                |     1 |   0.09K | 0.002 |
| _includes/articles.html    |     6 |   0.30K | 0.002 |
| tips.md                    |     1 |   0.05K | 0.002 |
| about.md                   |     1 |   2.33K | 0.002 |
| news.md                    |     1 |   0.06K | 0.001 |
| 404.html                   |     1 |   3.03K | 0.001 |
| contact.md                 |     1 |   0.58K | 0.000 |
+----------------------------+-------+---------+-------+
| TOTAL (for 21 files)       |    92 | 322.97K | 0.192 |

Building site for language: "kana" to: /Users/yasulab/mekurun.com/_site/kana
       Jekyll Feed: Generating feed for posts
Loading translation from file /Users/yasulab/mekurun.com/_i18n/kana.yml
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:404
Using translation '404 Page Not Found' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:description
Using translation 'メクルン (Mekurun) はスライドで学べる無料のプログラミング学習サイトです。ScratchやMakeCodeを中心に、作りながら学べる入門コンテンツを提供しています。「自分で考えて創る」ことで、主体的に自分のアイデアをカタチにできる創造性を育みます。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:about.description
Using translation 'メクルンについて知りたい方はこちらをご覧ください。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:contact.description
Using translation 'メクルンへのお問い合わせはこちらのフォームからお願いします。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:faq.description
Using translation 'メクルンのよくあるご質問についてはこちらをご覧ください。' from default language: ja
    Liquid Warning: Liquid syntax error (line 39): Expected dotdot but found comparison in "(course_lang == site.lang or (course_lang == 'ja' and site.lang == 'kana'))" in index.markdown
Missing i18n key: kana:top.courses
Using translation 'コース' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:description
Using translation 'メクルン (Mekurun) はスライドで学べる無料のプログラミング学習サイトです。ScratchやMakeCodeを中心に、作りながら学べる入門コンテンツを提供しています。「自分で考えて創る」ことで、主体的に自分のアイデアをカタチにできる創造性を育みます。' from default language: ja
Missing i18n key: kana:news.copy
Using translation 'メクルンからのアップデートやメンテナンスのお知らせ' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:news.description
Using translation '運営からのお知らせを掲載しています。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:privacy.description
Using translation 'メクルンのプライバシーポリシーについてはこちらをご覧ください。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:projects.description
Using translation 'みんなのScratch(スクラッチ)やMakeCode(メイクコード)を使ったものづくりを紹介する記事を定期的に投稿しています。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:termOfUse.description
Using translation 'メクルンの教材コンテンツをご利用いただく際の規定についてはこちらをご覧ください。' from default language: ja
Missing i18n key: kana:tips.copy
Using translation '作品を作るときに役立つ情報や、プログラミングに関する情報を紹介' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:tips.description
Using translation 'Scratch(スクラッチ)やMakeCode(メイクコード)に関する豆知識やプログラミングやテクノロジーに関する記事を定期的に投稿しています。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:usage.description
Using translation 'メクルンの使い方についてはこちらをご覧ください。' from default language: ja

| Filename                   | Count |   Bytes |  Time |
+----------------------------+-------+---------+-------+
| _layouts/course.html       |     8 |  49.99K | 0.024 |
| sitemap.xml                |     1 |   3.00K | 0.023 |
| _layouts/default.html      |    21 | 195.08K | 0.016 |
| _layouts/page.html         |     9 |  37.50K | 0.014 |
| _includes/footer.html      |    13 |  20.76K | 0.011 |
| _layouts/category.html     |     2 |   9.32K | 0.011 |
| index.markdown             |     1 |   7.85K | 0.008 |
| feed.xml                   |     1 |   0.81K | 0.008 |
| _includes/header.html      |    12 |   9.27K | 0.005 |
| _includes/course-list.html |     8 |   2.33K | 0.005 |
| privacy.md                 |     1 |   4.40K | 0.004 |
| usage.md                   |     1 |   1.44K | 0.004 |
| projects.md                |     1 |   0.09K | 0.003 |
| faq.md                     |     1 |   3.61K | 0.003 |
| term-of-use.md             |     1 |   2.57K | 0.003 |
| about.md                   |     1 |   2.33K | 0.003 |
| _includes/articles.html    |     6 |   0.30K | 0.002 |
| 404.html                   |     1 |   3.21K | 0.002 |
| tips.md                    |     1 |   0.05K | 0.001 |
| news.md                    |     1 |   0.06K | 0.001 |
| contact.md                 |     1 |   0.62K | 0.000 |
+----------------------------+-------+---------+-------+
| TOTAL (for 21 files)       |    92 | 354.59K | 0.150 |

Build complete

                    done in 2.81 seconds.

 Auto-regeneration: disabled. Use --watch to enable.
```
</details>


## After

<details>
<summary>Done in <b>2.077 seconds.</b>(Longest time out of 3 tries)</summary>

```
bundle exec jekyll build --profile

Configuration file: /Users/yasulab/mekurun.com/_config.yml
            Source: /Users/yasulab/mekurun.com
       Destination: /Users/yasulab/mekurun.com/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
Building site for default language: "ja" to: /Users/yasulab/mekurun.com/_site
       Jekyll Feed: Generating feed for posts
Loading translation from file /Users/yasulab/mekurun.com/_i18n/ja.yml
    Liquid Warning: Liquid syntax error (line 39): Expected dotdot but found comparison in "(course_lang == site.lang or (course_lang == 'ja' and site.lang == 'kana'))" in index.markdown

| Filename                   | Count |   Bytes |  Time |
+----------------------------+-------+---------+-------+
| sitemap.xml                |     1 |   3.08K | 0.015 |
| _layouts/course.html       |     8 |  49.84K | 0.013 |
| feed.xml                   |     1 |  15.32K | 0.012 |
| _layouts/page.html         |     9 |  37.51K | 0.008 |
| _layouts/default.html      |    23 | 221.64K | 0.007 |
| index.markdown             |     1 |   8.40K | 0.006 |
| _includes/footer.html      |    15 |  22.85K | 0.006 |
| _layouts/category.html     |     2 |   8.98K | 0.005 |
| _includes/header.html      |    14 |  10.72K | 0.004 |
| privacy.md                 |     1 |   4.40K | 0.003 |
| _layouts/post.html         |     2 |  18.04K | 0.003 |
| term-of-use.md             |     1 |   2.57K | 0.003 |
| _includes/course-list.html |     8 |   2.30K | 0.002 |
| usage.md                   |     1 |   1.44K | 0.002 |
| faq.md                     |     1 |   3.61K | 0.002 |
| projects.md                |     1 |   0.09K | 0.002 |
| about.md                   |     1 |   2.33K | 0.002 |
| _includes/articles.html    |     6 |   1.85K | 0.001 |
| tips.md                    |     1 |   0.83K | 0.001 |
| news.md                    |     1 |   0.06K | 0.001 |
| 404.html                   |     1 |   3.14K | 0.001 |
| contact.md                 |     1 |   0.62K | 0.000 |
+----------------------------+-------+---------+-------+
| TOTAL (for 22 files)       |   100 | 419.62K | 0.098 |

Building site for language: "en" to: /Users/yasulab/mekurun.com/_site/en
       Jekyll Feed: Generating feed for posts
Loading translation from file /Users/yasulab/mekurun.com/_i18n/en.yml
Missing i18n key: en:404
Using translation '404 Page Not Found' from default language: ja
Missing i18n key: en:about.description
Using translation 'メクルンについて知りたい方はこちらをご覧ください。' from default language: ja
Missing i18n key: en:contact.description
Using translation 'メクルンへのお問い合わせはこちらのフォームからお願いします。' from default language: ja
Missing i18n key: en:faq.description
Using translation 'メクルンのよくあるご質問についてはこちらをご覧ください。' from default language: ja
    Liquid Warning: Liquid syntax error (line 39): Expected dotdot but found comparison in "(course_lang == site.lang or (course_lang == 'ja' and site.lang == 'kana'))" in index.markdown
Missing i18n key: en:news.copy
Using translation 'メクルンからのアップデートやメンテナンスのお知らせ' from default language: ja
Missing i18n key: en:news.description
Using translation '運営からのお知らせを掲載しています。' from default language: ja
Missing i18n key: en:privacy.description
Using translation 'メクルンのプライバシーポリシーについてはこちらをご覧ください。' from default language: ja
Missing i18n key: en:projects.description
Using translation 'みんなのScratch(スクラッチ)やMakeCode(メイクコード)を使ったものづくりを紹介する記事を定期的に投稿しています。' from default language: ja
Missing i18n key: en:termOfUse.description
Using translation 'メクルンの教材コンテンツをご利用いただく際の規定についてはこちらをご覧ください。' from default language: ja
Missing i18n key: en:tips.copy
Using translation '作品を作るときに役立つ情報や、プログラミングに関する情報を紹介' from default language: ja
Missing i18n key: en:tips.description
Using translation 'Scratch(スクラッチ)やMakeCode(メイクコード)に関する豆知識やプログラミングやテクノロジーに関する記事を定期的に投稿しています。' from default language: ja
Missing i18n key: en:usage.description
Using translation 'メクルンの使い方についてはこちらをご覧ください。' from default language: ja

| Filename                   | Count |   Bytes |  Time |
+----------------------------+-------+---------+-------+
| sitemap.xml                |     1 |   2.94K | 0.029 |
| _layouts/course.html       |     8 |  49.74K | 0.028 |
| _layouts/page.html         |     9 |  33.68K | 0.014 |
| _layouts/default.html      |    21 | 181.22K | 0.012 |
| _includes/footer.html      |    13 |  18.42K | 0.009 |
| _layouts/category.html     |     2 |   6.29K | 0.007 |
| feed.xml                   |     1 |   0.80K | 0.006 |
| privacy.md                 |     1 |   4.40K | 0.006 |
| _includes/header.html      |    12 |   6.54K | 0.004 |
| term-of-use.md             |     1 |   2.57K | 0.004 |
| index.markdown             |     1 |   4.35K | 0.003 |
| usage.md                   |     1 |   1.44K | 0.003 |
| _includes/course-list.html |     8 |   0.53K | 0.003 |
| faq.md                     |     1 |   3.61K | 0.002 |
| about.md                   |     1 |   2.33K | 0.002 |
| projects.md                |     1 |   0.09K | 0.002 |
| tips.md                    |     1 |   0.05K | 0.001 |
| 404.html                   |     1 |   3.03K | 0.001 |
| news.md                    |     1 |   0.06K | 0.001 |
| _includes/articles.html    |     6 |   0.30K | 0.001 |
| contact.md                 |     1 |   0.58K | 0.000 |
+----------------------------+-------+---------+-------+
| TOTAL (for 21 files)       |    92 | 322.97K | 0.136 |

Building site for language: "kana" to: /Users/yasulab/mekurun.com/_site/kana
       Jekyll Feed: Generating feed for posts
Loading translation from file /Users/yasulab/mekurun.com/_i18n/kana.yml
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:course.prev
Using translation 'もどる' from default language: ja
Missing i18n key: kana:course.next
Using translation 'すすむ' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:404
Using translation '404 Page Not Found' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:description
Using translation 'メクルン (Mekurun) はスライドで学べる無料のプログラミング学習サイトです。ScratchやMakeCodeを中心に、作りながら学べる入門コンテンツを提供しています。「自分で考えて創る」ことで、主体的に自分のアイデアをカタチにできる創造性を育みます。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:about.description
Using translation 'メクルンについて知りたい方はこちらをご覧ください。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:contact.description
Using translation 'メクルンへのお問い合わせはこちらのフォームからお願いします。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:faq.description
Using translation 'メクルンのよくあるご質問についてはこちらをご覧ください。' from default language: ja
    Liquid Warning: Liquid syntax error (line 39): Expected dotdot but found comparison in "(course_lang == site.lang or (course_lang == 'ja' and site.lang == 'kana'))" in index.markdown
Missing i18n key: kana:top.courses
Using translation 'コース' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:description
Using translation 'メクルン (Mekurun) はスライドで学べる無料のプログラミング学習サイトです。ScratchやMakeCodeを中心に、作りながら学べる入門コンテンツを提供しています。「自分で考えて創る」ことで、主体的に自分のアイデアをカタチにできる創造性を育みます。' from default language: ja
Missing i18n key: kana:news.copy
Using translation 'メクルンからのアップデートやメンテナンスのお知らせ' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:news.description
Using translation '運営からのお知らせを掲載しています。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:privacy.description
Using translation 'メクルンのプライバシーポリシーについてはこちらをご覧ください。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:projects.description
Using translation 'みんなのScratch(スクラッチ)やMakeCode(メイクコード)を使ったものづくりを紹介する記事を定期的に投稿しています。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:termOfUse.description
Using translation 'メクルンの教材コンテンツをご利用いただく際の規定についてはこちらをご覧ください。' from default language: ja
Missing i18n key: kana:tips.copy
Using translation '作品を作るときに役立つ情報や、プログラミングに関する情報を紹介' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:tips.description
Using translation 'Scratch(スクラッチ)やMakeCode(メイクコード)に関する豆知識やプログラミングやテクノロジーに関する記事を定期的に投稿しています。' from default language: ja
Missing i18n key: kana:privacy.title
Using translation 'プライバシーポリシー' from default language: ja
Missing i18n key: kana:copy
Using translation '子ども向けプログラミング学習サイトならメクルン[Mekurun]' from default language: ja
Missing i18n key: kana:usage.description
Using translation 'メクルンの使い方についてはこちらをご覧ください。' from default language: ja

| Filename                   | Count |   Bytes |  Time |
+----------------------------+-------+---------+-------+
| _layouts/course.html       |     8 |  49.99K | 0.042 |
| _layouts/default.html      |    21 | 195.08K | 0.025 |
| sitemap.xml                |     1 |   3.00K | 0.021 |
| _layouts/page.html         |     9 |  37.50K | 0.019 |
| _includes/footer.html      |    13 |  20.76K | 0.013 |
| _layouts/category.html     |     2 |   9.32K | 0.010 |
| index.markdown             |     1 |   7.85K | 0.006 |
| _includes/header.html      |    12 |   9.27K | 0.006 |
| privacy.md                 |     1 |   4.40K | 0.005 |
| feed.xml                   |     1 |   0.81K | 0.005 |
| _includes/course-list.html |     8 |   2.33K | 0.005 |
| term-of-use.md             |     1 |   2.57K | 0.004 |
| faq.md                     |     1 |   3.61K | 0.004 |
| usage.md                   |     1 |   1.44K | 0.003 |
| about.md                   |     1 |   2.33K | 0.003 |
| projects.md                |     1 |   0.09K | 0.002 |
| news.md                    |     1 |   0.06K | 0.002 |
| _includes/articles.html    |     6 |   0.30K | 0.002 |
| 404.html                   |     1 |   3.21K | 0.001 |
| tips.md                    |     1 |   0.05K | 0.001 |
| contact.md                 |     1 |   0.62K | 0.000 |
+----------------------------+-------+---------+-------+
| TOTAL (for 21 files)       |    92 | 354.59K | 0.180 |

Build complete

                    done in 2.077 seconds.

 Auto-regeneration: disabled. Use --watch to enable.
```

</details>